### PR TITLE
fix(mobile): keep character card visible when keyboard opens (#1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/racoon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+    />
     <title>倉頡練習</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,11 @@ import React, { useState, useEffect } from "react";
 import Header from "./components/Header";
 import GameContainer from "./components/GameContainer";
 import { RadicalGuide } from "./components/RadicalGuide";
+import { useVisualViewportInset } from "./hooks/useVisualViewportInset";
 
 const App: React.FC = () => {
   const [darkMode, setDarkMode] = useState(false);
+  useVisualViewportInset();
 
   useEffect(() => {
     document.body.classList.toggle("dark", darkMode);
@@ -12,11 +14,11 @@ const App: React.FC = () => {
 
   return (
     <div
-      className={` min-h-screen align-centre transition-all  ${
+      className={`min-h-dvh flex flex-col transition-all ${
         darkMode ? "bg-gray-900 text-white" : "bg-slate-100 text-gray-900"
       }`}
     >
-      <div className="justify-between top-8 transform  p-4 flex items-center">
+      <div className="shrink-0 flex justify-between items-center p-4">
         <RadicalGuide />
         <div
           className="p-2 rounded-full cursor-pointer bg-gray-200 dark:bg-gray-800 shadow-lg"
@@ -25,8 +27,10 @@ const App: React.FC = () => {
           🌓
         </div>
       </div>
-      <Header />
-      <GameContainer />
+      <div className="flex-1 flex flex-col min-h-0">
+        <Header />
+        <GameContainer />
+      </div>
     </div>
   );
 };

--- a/src/components/CharacterDisplay.tsx
+++ b/src/components/CharacterDisplay.tsx
@@ -11,8 +11,8 @@ const CharacterDisplay: React.FC<CharacterDisplayProps> = ({ character }) => {
   const [showHint, setShowHint] = useState(false);
 
   return (
-    <div className="w-72 h-72 bg-gray-100 dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center justify-center p-8 transition-all">
-      <div className="text-8xl mb-4">{character.char}</div>
+    <div className="w-[min(18rem,85vw)] aspect-square max-w-[18rem] bg-gray-100 dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center justify-center p-4 sm:p-8 transition-all">
+      <div className="text-6xl sm:text-8xl mb-2 sm:mb-4">{character.char}</div>
       <button
         className="mt-4 px-4 py-2 bg-slate-500 text-white rounded-lg flex items-center"
         onClick={() => setShowHint(!showHint)}

--- a/src/components/GameContainer.tsx
+++ b/src/components/GameContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import CharacterDisplay from "./CharacterDisplay";
 import InputArea from "./InputArea";
 import Stats from "./Stats";
@@ -25,10 +25,18 @@ const GameContainer: React.FC = () => {
   );
   const [errorMessage, setErrorMessage] = useState("");
   const [shake, setShake] = useState(false);
+  const characterCardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setShuffledDictionary(shuffleArray(dictionary));
   }, []);
+
+  const scrollCardIntoView = () => {
+    characterCardRef.current?.scrollIntoView({
+      block: "nearest",
+      behavior: "smooth",
+    });
+  };
 
   const updateCharacter = () => {
     setCurrentCharIndex(
@@ -55,25 +63,29 @@ const GameContainer: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col items-center gap-8 pb-2">
-      <CharacterDisplay character={shuffledDictionary[currentCharIndex]} />
-      <div className={shake ? "animate-shake" : ""}>
-        <InputArea onInput={handleInput} />
+    <div className="flex-1 min-h-0 flex flex-col items-center gap-4 md:gap-8 overflow-y-auto pb-[var(--vv-bottom-inset,0px)] px-2">
+      <div ref={characterCardRef} className="shrink-0">
+        <CharacterDisplay character={shuffledDictionary[currentCharIndex]} />
+      </div>
+      <div className={`shrink-0 ${shake ? "animate-shake" : ""}`}>
+        <InputArea onInput={handleInput} onInputFocus={scrollCardIntoView} />
       </div>
       {errorMessage && (
-        <div className="text-red-500 font-bold animate-pulse">
+        <div className="text-red-500 font-bold animate-pulse shrink-0">
           {errorMessage}
         </div>
       )}
-      <Stats
-        score={score}
-        combo={combo}
-        accuracy={
-          totalAttempts === 0
-            ? 0
-            : Math.round((correctAttempts / totalAttempts) * 100)
-        }
-      />
+      <div className="w-full flex justify-center md:mt-auto shrink-0 pb-2">
+        <Stats
+          score={score}
+          combo={combo}
+          accuracy={
+            totalAttempts === 0
+              ? 0
+              : Math.round((correctAttempts / totalAttempts) * 100)
+          }
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -3,9 +3,10 @@ import { radicals } from "./RadicalGuide";
 
 interface InputAreaProps {
   onInput: (input: string) => void;
+  onInputFocus?: () => void;
 }
 
-const InputArea: React.FC<InputAreaProps> = ({ onInput }) => {
+const InputArea: React.FC<InputAreaProps> = ({ onInput, onInputFocus }) => {
   const [input, setInput] = useState("");
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,6 +45,7 @@ const InputArea: React.FC<InputAreaProps> = ({ onInput }) => {
         value={input}
         onChange={handleChange}
         onKeyDown={handleKeyPress}
+        onFocus={onInputFocus}
         placeholder="請輸入倉頡碼(英文鍵)"
         className="border-none w-full p-4 text-xl rounded-lg bg-gray-100 dark:bg-gray-800 shadow-lg text-center"
       />

--- a/src/hooks/useVisualViewportInset.ts
+++ b/src/hooks/useVisualViewportInset.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+
+/**
+ * Sets --vv-bottom-inset on documentElement so scrollable regions can pad
+ * above the virtual keyboard when the layout viewport does not shrink.
+ */
+export function useVisualViewportInset(): void {
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) {
+      return;
+    }
+
+    const update = () => {
+      const bottom = Math.max(
+        0,
+        window.innerHeight - (vv.height + vv.offsetTop)
+      );
+      document.documentElement.style.setProperty(
+        "--vv-bottom-inset",
+        `${bottom}px`
+      );
+    };
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+      document.documentElement.style.removeProperty("--vv-bottom-inset");
+    };
+  }, []);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [issue #1](https://github.com/eugenieeeech/cangjie-practice/issues/1): on mobile, the virtual keyboard overlapped the character card and forced awkward scrolling.

## Changes

- **Viewport:** `interactive-widget=resizes-content` in `index.html` so Chromium-based browsers can resize the layout viewport when the keyboard opens.
- **App shell:** `min-h-dvh` with a flex column; main content uses `flex-1 min-h-0` so the play area can shrink and scroll internally.
- **Visual viewport:** New `useVisualViewportInset` hook sets `--vv-bottom-inset` on `documentElement` for browsers that do not shrink the layout; `GameContainer` applies `padding-bottom` from that variable so content clears the keyboard.
- **Game area:** `flex-1 min-h-0 overflow-y-auto` on the game column; `Stats` wrapped with `md:mt-auto` so stats sit lower on larger screens without pushing the card away on small viewports.
- **Character card:** Responsive width (`min(18rem, 85vw)`), `aspect-square`, and smaller character text on narrow breakpoints.
- **Input focus:** Optional `onInputFocus` scrolls the card into view with `scrollIntoView({ block: 'nearest', behavior: 'smooth' })`.

## Verification

- `npm run lint` (existing warning in `RadicalGuide.tsx` only)
- `npm run build` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bfcefca-98d4-4509-9ee4-025674fbcf33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bfcefca-98d4-4509-9ee4-025674fbcf33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

